### PR TITLE
TL-465 run coverage stats and add coverage and TravisCI badges

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+service_name: travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
 sudo: false
+cache: bundler
 rvm:
   - 2.2.2

--- a/Gemfile
+++ b/Gemfile
@@ -26,4 +26,6 @@ group :development do
   gem 'rspec-collection_matchers'
 
   gem 'fuubar'
+
+  gem 'coveralls'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,16 @@ GEM
       columnize (= 0.9.0)
     coderay (1.1.0)
     columnize (0.9.0)
+    coveralls (0.8.2)
+      json (~> 1.8)
+      rest-client (>= 1.6.8, < 2)
+      simplecov (~> 0.10.0)
+      term-ansicolor (~> 1.3)
+      thor (~> 0.19.1)
     diff-lcs (1.2.5)
+    docile (1.1.5)
+    domain_name (0.5.24)
+      unf (>= 0.0.5, < 1.0.0)
     factory_girl (4.5.0)
       activesupport (>= 3.0.0)
     ffi (1.9.10)
@@ -41,6 +50,8 @@ GEM
     harness (2.0.0)
       statsd-ruby
     hashie (3.4.2)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
     i18n (0.7.0)
     json (1.8.3)
     listen (3.0.3)
@@ -49,11 +60,13 @@ GEM
     lumberjack (1.0.9)
     method_source (0.8.2)
     mime (0.4.2)
+    mime-types (2.6.1)
     mini_portile (0.6.2)
     minitest (5.8.1)
     mustermann (0.4.0)
       tool (~> 0.2)
     nenv (0.2.0)
+    netrc (0.10.3)
     newrelic-praxis (1.1)
       activesupport (>= 3)
       newrelic_rpm (>= 3.13)
@@ -100,6 +113,10 @@ GEM
     rb-fsevent (0.9.6)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     rspec (3.3.0)
       rspec-core (~> 3.3.0)
       rspec-expectations (~> 3.3.0)
@@ -121,21 +138,33 @@ GEM
     ruby-progressbar (1.7.5)
     sequel (4.26.0)
     shellany (0.0.1)
+    simplecov (0.10.0)
+      docile (~> 1.1.0)
+      json (~> 1.8)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
     slop (3.6.0)
     sqlite3 (1.3.10)
     statsd-ruby (1.2.1)
+    term-ansicolor (1.3.2)
+      tins (~> 1.0)
     terminal-table (1.5.2)
     thor (0.19.1)
     thread_safe (0.3.5)
+    tins (1.6.0)
     tool (0.2.3)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   builder
+  coveralls
   factory_girl
   fuubar
   guard

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Bloggy Example Praxis Application
 
+[![Build Status](https://travis-ci.org/rightscale/praxis-example-app.svg?branch=master)](https://travis-ci.org/rightscale/praxis-example-app)
+[![Coverage Status](https://coveralls.io/repos/rightscale/praxis-example-app/badge.svg?branch=master&service=github)](https://coveralls.io/github/rightscale/praxis-example-app?branch=master)
+
 Bloggy is a simple (and nowhere near feature-complete) example of a Praxis application. It's designed to demonstrate a various features of Praxis and show the overall structure of a full application.
 
 See the [Getting Started](http://praxis-framework.io/getting-started/) guide on the Praxis website for more information about the structure of a Praxis application.

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,6 @@
+require 'coveralls'
+Coveralls.wear!
+
 require 'bundler/setup'
 Bundler.setup :default, :test
 


### PR DESCRIPTION
This runs Code Coverage metrics and adds the CodeCoverage metric and TravisCI build badge.

We are adding these badges to all our public Ruby repos.

Travis building has been activated for this repo.
Travis cache of gems has been added to .travis.yml file
